### PR TITLE
Improved Accessibility to WCAG AA and Improved UI margins

### DIFF
--- a/src/layout/components/AboutPage/index.tsx
+++ b/src/layout/components/AboutPage/index.tsx
@@ -128,7 +128,7 @@ const AboutPage: React.FC = () => (
               target="_blank"
               rel="noopener noreferrer"
             >
-              NSF-funded IUSE
+              NSF-funded IUSE<span className="sr-only"> (opens in new tab)</span>
             </a>{' '}
             project extends previous work (see{' '}
             <a
@@ -136,7 +136,7 @@ const AboutPage: React.FC = () => (
               target="_blank"
               rel="noopener noreferrer"
             >
-              OCCTIVE Version 1
+              OCCTIVE Version 1<span className="sr-only"> (opens in new tab)</span>
             </a>
             , including the{' '}
             <a
@@ -144,7 +144,7 @@ const AboutPage: React.FC = () => (
               target="_blank"
               rel="noopener noreferrer"
             >
-              archive of earlier videos
+              archive of earlier videos<span className="sr-only"> (opens in new tab)</span>
             </a>
             ). The earlier project led to the initial development of{' '}
             <strong>
@@ -188,7 +188,7 @@ const AboutPage: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            https://dl.acm.org/doi/10.1145/3770761.3777292
+            https://dl.acm.org/doi/10.1145/3770761.3777292<span className="sr-only"> (opens in new tab)</span>
           </a>
         </p>
       </div>

--- a/src/layout/components/AboutPage/style.scss
+++ b/src/layout/components/AboutPage/style.scss
@@ -50,6 +50,11 @@ $about-teal-light: #4a6d75;
         text-decoration: none !important;
         transform: scale(1.02);
       }
+
+      &:focus-visible {
+        outline: 3px solid #005fcc;
+        outline-offset: 3px;
+      }
     }
 
     .btn-primary {

--- a/src/layout/components/AdoptPage/index.tsx
+++ b/src/layout/components/AdoptPage/index.tsx
@@ -72,7 +72,7 @@ const AdoptPage: React.FC = () => (
             rel="noopener noreferrer"
             className="btn-primary"
           >
-            <b>Fill Out Our Interest Form</b>
+            <b>Fill Out Our Interest Form</b><span className="sr-only"> (opens in new tab)</span>
           </a>
           <a
             href="mailto:occtive@gmail.com"
@@ -106,7 +106,7 @@ const AdoptPage: React.FC = () => (
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                flowchart
+                flowchart<span className="sr-only"> (opens in new tab)</span>
               </a>{' '}
               that shows video dependencies.
             </p>
@@ -130,7 +130,7 @@ const AdoptPage: React.FC = () => (
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                document
+                document<span className="sr-only"> (opens in new tab)</span>
               </a>{' '}
               contains a number of exercises that provide examples for faculty who would like to
               create their own reinforcing exercises students can work on after watching the videos.
@@ -153,7 +153,7 @@ const AdoptPage: React.FC = () => (
               target="_blank"
               rel="noopener noreferrer"
             >
-              RStudio Cheatsheets
+              RStudio Cheatsheets<span className="sr-only"> (opens in new tab)</span>
             </a>
           </li>
           <li>
@@ -163,7 +163,7 @@ const AdoptPage: React.FC = () => (
               target="_blank"
               rel="noopener noreferrer"
             >
-              Advanced R, a style guide by Hadley Wickham
+              Advanced R, a style guide by Hadley Wickham<span className="sr-only"> (opens in new tab)</span>
             </a>
           </li>
           <li>
@@ -174,7 +174,7 @@ const AdoptPage: React.FC = () => (
               rel="noopener noreferrer"
             >
               Modern Data Science with R by Benjamin S. Baumer, Daniel T. Kaplan, and Nicholas
-              Horton
+              Horton<span className="sr-only"> (opens in new tab)</span>
             </a>
           </li>
           <li>
@@ -184,7 +184,7 @@ const AdoptPage: React.FC = () => (
               target="_blank"
               rel="noopener noreferrer"
             >
-              Data Feminism by Catherine D&rsquo;Ignazio and Lauren F. Klein
+              Data Feminism by Catherine D&rsquo;Ignazio and Lauren F. Klein<span className="sr-only"> (opens in new tab)</span>
             </a>
           </li>
         </ul>

--- a/src/layout/components/AdoptPage/style.scss
+++ b/src/layout/components/AdoptPage/style.scss
@@ -78,6 +78,11 @@
         text-decoration: none !important;
         transform: scale(1.02);
       }
+
+      &:focus-visible {
+        outline: 3px solid #005fcc;
+        outline-offset: 3px;
+      }
     }
 
     .btn-primary {

--- a/src/layout/components/DependencyGraph/index.tsx
+++ b/src/layout/components/DependencyGraph/index.tsx
@@ -1,7 +1,9 @@
 // File: src/layout/components/DependencyGraph/index.tsx
 // Renders an accessible modal dialog containing a visual dependency graph.
 
-import React, { useEffect, useState } from 'react';
+import React, {
+  useEffect, useState, useRef, useCallback,
+} from 'react';
 import ReactDOM from 'react-dom';
 import ReactFlow, { Background, ReactFlowProvider } from 'reactflow';
 import dagre from '@dagrejs/dagre';
@@ -241,26 +243,93 @@ const DependencyGraph: React.FC<DependencyGraphProps> = ({
   groupColorKeys,
   topicColorMap,
 }) => {
-  /* Block scroll when modal is open */
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  /* Close modal and restore focus to the element that opened it */
+  const handleClose = useCallback(() => {
+    onClose();
+    requestAnimationFrame(() => {
+      triggerRef.current?.focus();
+    });
+  }, [onClose]);
+
+  /* Block scroll and mark background inert when modal is open */
   useEffect(() => {
+    const mainEl = document.getElementById('main-content');
+    const headerEl = document.querySelector('header');
+    const footerEl = document.querySelector('footer');
+
     if (isOpen) {
+      triggerRef.current = document.activeElement as HTMLElement;
       document.body.style.overflow = 'hidden';
+      [mainEl, headerEl, footerEl].forEach((el) => {
+        if (el) el.setAttribute('inert', '');
+      });
     } else {
       document.body.style.overflow = '';
+      [mainEl, headerEl, footerEl].forEach((el) => {
+        if (el) el.removeAttribute('inert');
+      });
     }
     return () => {
       document.body.style.overflow = '';
+      [mainEl, headerEl, footerEl].forEach((el) => {
+        if (el) el.removeAttribute('inert');
+      });
     };
   }, [isOpen]);
 
   /* ESC key closes modal */
   useEffect(() => {
     function handleEsc(e: KeyboardEvent) {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') handleClose();
     }
     if (isOpen) window.addEventListener('keydown', handleEsc);
     return () => window.removeEventListener('keydown', handleEsc);
-  }, [isOpen, onClose]);
+  }, [isOpen, handleClose]);
+
+  /* Focus trap: keep focus inside dialog while open */
+  useEffect(() => {
+    if (!isOpen || !dialogRef.current) return () => {};
+
+    const FOCUSABLE = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+
+    /* Move initial focus to the first focusable element (close button) */
+    const focusable = Array.from(
+      dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE),
+    );
+    if (focusable.length > 0) focusable[0].focus();
+
+    function trapFocus(e: KeyboardEvent) {
+      if (e.key !== 'Tab' || !dialogRef.current) return;
+      const els = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE),
+      ).filter((el) => !el.closest('[aria-hidden="true"]'));
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    window.addEventListener('keydown', trapFocus);
+    return () => window.removeEventListener('keydown', trapFocus);
+  }, [isOpen]);
 
   const { nodes: rawNodes, edges: rawEdges } = useGraphFromSheet();
   const [legendCollapsed, setLegendCollapsed] = useState(true);
@@ -351,7 +420,7 @@ const DependencyGraph: React.FC<DependencyGraphProps> = ({
     <>
       {/* Visual overlay blocks background interaction */}
       <div
-        onClick={onClose}
+        onClick={handleClose}
         style={{
           position: 'fixed',
           inset: 0,
@@ -364,7 +433,10 @@ const DependencyGraph: React.FC<DependencyGraphProps> = ({
 
       {/* Dialog container for dependency graph */}
       <div
-        onClick={(e) => e.stopPropagation()}
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dep-graph-title"
         style={{
           position: 'fixed',
           top: '50%',
@@ -382,9 +454,27 @@ const DependencyGraph: React.FC<DependencyGraphProps> = ({
           animation: 'fadeIn 0.15s ease-out',
         }}
       >
+        {/* Visually hidden title for screen readers */}
+        <h2
+          id="dep-graph-title"
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            border: 0,
+          }}
+        >
+          Dependency Graph
+        </h2>
+
         {/* Close button */}
         <button
-          onClick={onClose}
+          onClick={handleClose}
           aria-label="Close Dependency Graph"
           type="button"
           style={{

--- a/src/layout/components/Footer/index.tsx
+++ b/src/layout/components/Footer/index.tsx
@@ -14,8 +14,8 @@ const Footer: React.FC = () => (
         alt="OCCTIVE Logo"
       />
       <p className="footer-contact">Contact</p>
-      <a href="mailto:occtive@gmail.com">
-        <p className="footer-email">occtive@gmail.com</p>
+      <a href="mailto:occtive@gmail.com" className="footer-email">
+        occtive@gmail.com
       </a>
     </address>
 
@@ -26,8 +26,9 @@ const Footer: React.FC = () => (
         target="_blank"
         rel="noopener noreferrer"
         href="https://docs.google.com/forms/d/e/1FAIpQLSdy5MtrwNQZ9VHM32Tjm6UL3MTuc9vu-oQ9vknjkVrviUYC0g/viewform"
+        className="footer-issue-link"
       >
-        <p className="footer-issue-link">Fill out this form</p>
+        Fill out this form<span className="sr-only"> (opens in new tab)</span>
       </a>
     </section>
 
@@ -52,7 +53,7 @@ const Footer: React.FC = () => (
         <p className="footer-grant-text">
           Project material based upon work supported by the{' '}
           <a href="https://www.nsf.gov/" target="_blank" rel="noopener noreferrer">
-            National Science Foundation
+            National Science Foundation<span className="sr-only"> (opens in new tab)</span>
           </a>{' '}
           under Grant Numbers{' '}
           <a
@@ -60,7 +61,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            2337251
+            2337251<span className="sr-only"> (opens in new tab)</span>
           </a>
           ,{' '}
           <a
@@ -68,7 +69,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            2337252
+            2337252<span className="sr-only"> (opens in new tab)</span>
           </a>
           ,{' '}
           <a
@@ -76,7 +77,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            2337253
+            2337253<span className="sr-only"> (opens in new tab)</span>
           </a>
           ,{' '}
           <a
@@ -84,7 +85,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            2337254
+            2337254<span className="sr-only"> (opens in new tab)</span>
           </a>
           ,{' '}
           <a
@@ -92,7 +93,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            1935113
+            1935113<span className="sr-only"> (opens in new tab)</span>
           </a>
           ,{' '}
           <a
@@ -100,7 +101,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            1935099
+            1935099<span className="sr-only"> (opens in new tab)</span>
           </a>
           , and{' '}
           <a
@@ -108,7 +109,7 @@ const Footer: React.FC = () => (
             target="_blank"
             rel="noopener noreferrer"
           >
-            1935061
+            1935061<span className="sr-only"> (opens in new tab)</span>
           </a>
           . Any opinions, findings, and conclusions or recommendations expressed in this material
           are those of the author(s) and do not necessarily reflect the views of the

--- a/src/layout/components/Footer/style.scss
+++ b/src/layout/components/Footer/style.scss
@@ -34,8 +34,16 @@
 
 .footer-logo { width: 3rem; }
 
-.footer-contact { @include font-footer-heading-text; margin-top: 1rem; }
-.footer-email { @include font-footer-text;        margin-top: 0.5rem; }
+.footer-contact {
+  @include font-footer-heading-text;
+  margin-top: 1rem;
+}
+
+.footer-email { 
+  @include font-footer-text;
+  display: block;
+  margin-top: 0.5rem;
+}
 
 /* middle column — keep to ~2 lines max by bounding the width */
 .footer-issue {
@@ -47,6 +55,7 @@
 .footer-issue-link {
   @include font-footer-text;
   cursor: pointer;
+  display: block;
   margin-top: 1.25rem;
   overflow-wrap: anywhere;
   text-decoration-line: underline;

--- a/src/layout/components/Header/index.tsx
+++ b/src/layout/components/Header/index.tsx
@@ -2,7 +2,7 @@
 // Navigation header for OCCTIVE
 
 import React, { useState } from 'react';
-import { NavLink, Link } from 'react-router-dom';
+import { NavLink, Link, useLocation } from 'react-router-dom';
 import HeaderMenu from '../../../assets/HeaderMenu.svg';
 import { pages } from '../../../vars';
 import './style.scss';
@@ -10,6 +10,7 @@ import './style.scss';
 const Header: React.FC = () => {
   /* Controls visibility of the mobile navigation menu */
   const [menu, setMenu] = useState(false);
+  const { pathname } = useLocation();
 
   const closeMenu = () => {
     setMenu(false);
@@ -19,6 +20,10 @@ const Header: React.FC = () => {
     <>
       {/* Header landmark identifies site-wide banner */}
       <header className="header">
+        {/* Skip link — first tabbable element on every page */}
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
         <div className="header-content">
           <Link to="/" onClick={closeMenu}>
             <img
@@ -29,19 +34,23 @@ const Header: React.FC = () => {
           </Link>
 
           {/* ---------- DESKTOP LINKS ---------- */}
-          <div className="header-links">
-            {pages.map((page, index) => (
-              <NavLink
-                key={index}
-                to={page.link}
-                exact={page.link === '/'}
-                className="header-link"
-                activeClassName="active"
-              >
-                {page.title}
-              </NavLink>
-            ))}
-          </div>
+          <nav className="header-links" aria-label="Main navigation">
+            {pages.map((page, index) => {
+              const isActive = page.link === '/' ? pathname === '/' : pathname.startsWith(page.link);
+              return (
+                <NavLink
+                  key={index}
+                  to={page.link}
+                  exact={page.link === '/'}
+                  className="header-link"
+                  activeClassName="active"
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {page.title}
+                </NavLink>
+              );
+            })}
+          </nav>
 
           {/* ---------- HAMBURGER ---------- */}
           <div className="header-mobile">
@@ -50,31 +59,42 @@ const Header: React.FC = () => {
               type="button"
               onClick={() => setMenu(!menu)}
               aria-label="Toggle navigation menu"
+              aria-expanded={menu}
+              aria-controls="mobile-nav-menu"
             >
               <img
                 className="header-mobile-icon"
                 src={HeaderMenu}
-                alt="Mobile menu"
+                alt=""
+                aria-hidden="true"
               />
             </button>
           </div>
         </div>
 
         {/* ---------- MOBILE DROPDOWN ---------- */}
-        <div className={`header-mobile-links${menu ? ' open' : ''}`}>
-          {pages.map((page, index) => (
-            <NavLink
-              key={index}
-              to={page.link}
-              exact={page.link === '/'}
-              className="header-link"
-              activeClassName="active"
-              onClick={closeMenu}
-            >
-              {page.title}
-            </NavLink>
-          ))}
-        </div>
+        <nav
+          id="mobile-nav-menu"
+          className={`header-mobile-links${menu ? ' open' : ''}`}
+          aria-label="Mobile navigation"
+        >
+          {pages.map((page, index) => {
+            const isActive = page.link === '/' ? pathname === '/' : pathname.startsWith(page.link);
+            return (
+              <NavLink
+                key={index}
+                to={page.link}
+                exact={page.link === '/'}
+                className="header-link"
+                activeClassName="active"
+                onClick={closeMenu}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {page.title}
+              </NavLink>
+            );
+          })}
+        </nav>
       </header>
     </>
   );

--- a/src/layout/components/Header/style.scss
+++ b/src/layout/components/Header/style.scss
@@ -1,5 +1,32 @@
 @import '../../../styles';
 
+.skip-link {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+
+  &:focus-visible {
+    background: #005fcc;
+    border-radius: 4px;
+    clip: auto;
+    clip-path: none;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    height: auto;
+    left: 1rem;
+    overflow: visible;
+    padding: 0.75rem 1.25rem;
+    top: 1rem;
+    width: auto;
+    z-index: 9999;
+  }
+}
+
 .header {
   left: 0;
   max-width: 100%;
@@ -73,12 +100,20 @@
     }
 
     &:focus-visible {
-      outline: 3px solid rgba(0, 0, 0, 0.08);
+      outline: 3px solid #cdf1ff;
       outline-offset: 3px;
     }
   }
 
   /* ---------- HAMBURGER BUTTON ---------- */
+  &-mobile-button {
+    &:focus-visible {
+      border-radius: 4px;
+      outline: 3px solid #cdf1ff;
+      outline-offset: 3px;
+    }
+  }
+
   &-mobile {
     align-items: center;
     cursor: pointer;
@@ -116,7 +151,10 @@
     right: 0;
     top: 3.5rem; // directly under header
     transform: translateY(-100%);
-    transition: top 0.4s ease, opacity 0.3s ease, transform 0.3s ease;
+    /* visibility: hidden removes links from tab order when menu is closed;
+       delay matches the close animation so content fades out before disappearing */
+    transition: top 0.4s ease, opacity 0.3s ease, transform 0.3s ease, visibility 0s linear 0.3s;
+    visibility: hidden;
     width: 100%;
 
     &.open {
@@ -124,6 +162,9 @@
       pointer-events: auto;
       top: 2.75rem;
       transform: translateY(0);
+      /* visibility becomes visible immediately on open (no delay) */
+      transition: top 0.4s ease, opacity 0.3s ease, transform 0.3s ease, visibility 0s;
+      visibility: visible;
       z-index: 100;
     }
 

--- a/src/layout/components/HomeCard/index.tsx
+++ b/src/layout/components/HomeCard/index.tsx
@@ -168,8 +168,12 @@ const HomeCard: React.FC<HomeCardProps> = ({
         </section>
       </article>
 
-      {/* Toast feedback */}
-      {toast && <div className="copy-toast">{toast}</div>}
+      {/* Toast feedback — announced to screen readers via aria-live */}
+      {toast && (
+        <div className="copy-toast" role="status" aria-live="polite" aria-atomic="true">
+          {toast}
+        </div>
+      )}
     </>
   );
 };

--- a/src/layout/components/HomeCard/style.scss
+++ b/src/layout/components/HomeCard/style.scss
@@ -89,6 +89,7 @@
   align-items: center;
   background: none;
   border: 0;
+  border-radius: 4px;
   cursor: pointer;
   display: flex;
   margin: 0;
@@ -97,6 +98,11 @@
 
   &:hover {
     transform: scale(1.05);
+  }
+
+  &:focus-visible {
+    outline: 3px solid #005fcc;
+    outline-offset: 2px;
   }
 }
 

--- a/src/layout/components/HomePage/style.scss
+++ b/src/layout/components/HomePage/style.scss
@@ -237,6 +237,11 @@
       filter: brightness(1.05);
       transform: scale(1.02);
     }
+
+    &:focus-visible {
+      outline: 3px solid #005fcc;
+      outline-offset: 3px;
+    }
   }
 
   /* Primary button */

--- a/src/layout/components/PageLayout/PageLayout.tsx
+++ b/src/layout/components/PageLayout/PageLayout.tsx
@@ -18,7 +18,7 @@ const PageLayout: React.FC<PageLayoutProps> = (props) => {
 
   return (
     <>
-      <main className="content">
+      <main id="main-content" className="content" tabIndex={-1}>
         {children}
       </main>
     </>

--- a/src/layout/components/UnitCard/index.tsx
+++ b/src/layout/components/UnitCard/index.tsx
@@ -70,7 +70,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
           <div className="video-entry-left">
             <iframe
               src={toEmbed(video.u)}
-              title={`video-${idx}`}
+              title={video.t || `Video ${idx + 1}`}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
             />
@@ -89,7 +89,7 @@ const UnitCard: React.FC<UnitCardProps> = ({
               onClick={() => setOpen((s) => !s)}
               aria-expanded={open}
             >
-              <img src={DependencyChartBtnIcon} alt="Dependency Icon" className="dependency-icon" />
+              <img src={DependencyChartBtnIcon} alt="" aria-hidden="true" className="dependency-icon" />
               {open ? 'Hide Dependencies' : 'Dependencies'}
             </button>
           </section>

--- a/src/layout/components/UnitCard/style.scss
+++ b/src/layout/components/UnitCard/style.scss
@@ -78,7 +78,7 @@
 
   .btn-lightblue {
     @include font-button;
-    background-color: #71bfde;
+    background-color: #3d9ab8;
     border-radius: 8px;
     color: #f3f8f9;
     cursor: pointer;
@@ -87,6 +87,11 @@
     &:hover {
       filter: brightness(1.05);
       transform: scale(1.02);
+    }
+
+    &:focus-visible {
+      outline: 3px solid #005fcc;
+      outline-offset: 3px;
     }
   }
 }
@@ -102,7 +107,6 @@
   gap: 1.25rem;
   margin-top: 0.75rem;
   padding: 1.25rem 1.5rem;
-  width: 100%;
 }
 
 .video-entry-card {
@@ -156,7 +160,7 @@
   .btn-dependencies {
     align-items: center;
     align-self: flex-start;
-    background-color: #71bfde;
+    background-color: #3d9ab8;
     border: none;
     border-radius: 6px;
     color: #f3f8f9;
@@ -172,6 +176,11 @@
     &:hover {
       filter: brightness(1.05);
       transform: scale(1.02);
+    }
+
+    &:focus-visible {
+      outline: 3px solid #005fcc;
+      outline-offset: 3px;
     }
 
     img {

--- a/src/layout/components/UnitPage/style.scss
+++ b/src/layout/components/UnitPage/style.scss
@@ -58,7 +58,7 @@
     gap: 2.5rem;
     margin: 0 auto;
     max-width: 1550px;
-    padding: 2rem 2rem 3rem 2rem;
+    padding: 2rem 2rem 3rem;
   }
 
   &-sidebar {

--- a/src/layout/components/UnitPage/style.scss
+++ b/src/layout/components/UnitPage/style.scss
@@ -20,10 +20,17 @@
       background-color 0.2s ease,
       transform 0.15s ease;
 
-    &:hover,
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.08);
+      color: var(--unit-color, #71bfde);
+      transform: translateX(2px);
+    }
+
     &:focus-visible {
       background-color: rgba(255, 255, 255, 0.08);
       color: var(--unit-color, #71bfde);
+      outline: 3px solid #005fcc;
+      outline-offset: 3px;
       transform: translateX(2px);
     }
   }
@@ -51,7 +58,7 @@
     gap: 2.5rem;
     margin: 0 auto;
     max-width: 1550px;
-    padding: 2rem 2rem 3rem 0;
+    padding: 2rem 2rem 3rem 2rem;
   }
 
   &-sidebar {

--- a/src/layout/components/WorkshopPage/index.tsx
+++ b/src/layout/components/WorkshopPage/index.tsx
@@ -48,8 +48,8 @@ const WorkshopPage: React.FC = () => (
           Biology/Ecology, Physics, Astronomy, Chemistry, Statistics, Sociology, Psychology,
           Environmental Science. Of course, we welcome participants from the full range of
           academic disciplines!! If you are interested in participating, complete{' '}
-          <a className="adopt-link" href=" https://forms.gle/fkwd2ghG2xmphutS6" target="_blank" rel="noopener noreferrer">
-            this form
+          <a className="adopt-link" href="https://forms.gle/fkwd2ghG2xmphutS6" target="_blank" rel="noopener noreferrer">
+            this form<span className="sr-only"> (opens in new tab)</span>
           </a>
           .
         </p>
@@ -110,7 +110,7 @@ const WorkshopPage: React.FC = () => (
           given to faculty who fully engage with the project team. If you read this far and
           decided you’d like to adopt OCCTIVE but not attend the workshop, please{' '}
           <a className="adopt-link" href="https://forms.gle/CiLWR96ztVktb1TB9" target="_blank" rel="noopener noreferrer">
-            head here instead
+            head here instead<span className="sr-only"> (opens in new tab)</span>
           </a>
           .
         </p>

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -126,7 +126,7 @@ a img {
   border: 0;
 }
  
-:focus {
+:focus:not(:focus-visible) {
   outline: 0;
 }
  

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -1,4 +1,5 @@
 // Colors
+$color-focus-ring: #005fcc;
 $color-primary-navy: #1c2b4a;
 $color-primary-blue: #2a6ca6;
 $color-primary-mustard: #c09200;

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,3 +1,24 @@
+/* WCAG 2.4.7 — ensure a visible focus ring on every interactive element */
+*:focus-visible {
+  outline: 3px solid #005fcc;
+  outline-offset: 3px;
+}
+
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Visually hidden but readable by screen readers */
+.sr-only {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 /* Set the background color for the entire page */
 body {
   background-color: #f3f8f9;


### PR DESCRIPTION
Add skip-to-main-content link as first focusable element in header
Add global *:focus-visible focus ring that was suppressing all focus indicators
Fix near-invisible header nav focus outline
Add aria-expanded, aria-controls, and aria-current="page" to nav; wrap desktop/mobile links in <nav> landmarks; mark hamburger icon as decorative
Add visibility: hidden to closed mobile menu to remove it from tab order
Add role="dialog", aria-modal, aria-labelledby, focus trap, focus restoration, and inert on background elements to DependencyGraph modal
Add role="status" + aria-live="polite" to copy toast notifications
Fix .btn-lightblue color contrast failure
Add :focus-visible outlines to all buttons across HomePage, AboutPage, AdoptPage, and UnitPage sidebar
Fix UnitPage sidebar all: unset blocking focus ring; add explicit outline to :focus-visible
Use actual video title for iframe title attribute and marked decorative icons with alt=""
Flatten invalid <p> inside <a> in footer
Add .sr-only utility and annotate all target="_blank" links with "(opens in new tab)" for screen readers
Fix broken WorkshopPage URL
Add margins to Library page layout to prevent content sitting flush against screen edge